### PR TITLE
Load .env file in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --require @babel/register --colors",
-    "unit-test": "yarn test 'tests/setup.js' 'tests/unit/**/*.unit.js'",
-    "feature-test": "yarn test 'tests/setup.js' 'tests/feature/**/*.feature.js'",
+    "test": "mocha --require @babel/register --require tests/setup.js --colors",
+    "unit-test": "yarn test 'tests/unit/**/*.unit.js'",
+    "feature-test": "yarn test 'tests/feature/**/*.feature.js'",
     "offline-feature-test": "USE_SERVERLESS_OFFLINE=1 yarn feature-test"
   },
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --require @babel/register --colors",
-    "unit-test": "yarn test 'tests/unit/**/*.unit.js'",
-    "feature-test": "yarn test 'tests/feature/**/*.feature.js'"
+    "unit-test": "yarn test 'tests/setup.js' 'tests/unit/**/*.unit.js'",
+    "feature-test": "yarn test 'tests/setup.js' 'tests/feature/**/*.feature.js'"
   },
   "main": "index.js",
   "repository": "https://github.com/comicrelief/serverless-starter-app",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "lint": "eslint .",
     "test": "mocha --require @babel/register --colors",
     "unit-test": "yarn test 'tests/setup.js' 'tests/unit/**/*.unit.js'",
-    "feature-test": "yarn test 'tests/setup.js' 'tests/feature/**/*.feature.js'"
+    "feature-test": "yarn test 'tests/setup.js' 'tests/feature/**/*.feature.js'",
+    "offline-feature-test": "USE_SERVERLESS_OFFLINE=1 yarn feature-test"
   },
   "main": "index.js",
   "repository": "https://github.com/comicrelief/serverless-starter-app",

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,11 @@
+import chai from 'chai';
+import { config } from 'dotenv';
+
+// Global setup
+before(() => {
+  // Load environment variables from `.env`
+  config();
+
+  // Force chai to show the complete object diff
+  chai.config.truncateThreshold = 0;
+});

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -8,4 +8,13 @@ before(() => {
 
   // Force chai to show the complete object diff
   chai.config.truncateThreshold = 0;
+
+  // Execute the feature tests
+  // against serverless offline.
+  // Override URL and API Key
+  // To match `yarn offline-feature-test`
+  if (process.env.USE_SERVERLESS_OFFLINE) {
+    process.env.SERVICE_URL = 'http://localhost:3001';
+    process.env.SERVICE_KEY = 'api-key';
+  }
 });

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,20 +1,20 @@
 import chai from 'chai';
 import { config } from 'dotenv';
 
-// Global setup
-before(() => {
-  // Load environment variables from `.env`
-  config();
 
-  // Force chai to show the complete object diff
-  chai.config.truncateThreshold = 0;
+// Load environment variables from `.env`
+config();
 
+
+// Force chai to show the complete object diff
+chai.config.truncateThreshold = 0;
+
+
+if (process.env.USE_SERVERLESS_OFFLINE) {
   // Execute the feature tests
   // against serverless offline.
   // Override URL and API Key
   // To match `yarn offline-feature-test`
-  if (process.env.USE_SERVERLESS_OFFLINE) {
-    process.env.SERVICE_URL = 'http://localhost:3001';
-    process.env.SERVICE_KEY = 'api-key';
-  }
-});
+  process.env.SERVICE_URL = 'http://localhost:3001';
+  process.env.SERVICE_KEY = 'api-key';
+}


### PR DESCRIPTION
Currently we store secrets and other env variables in a .env file, which will be loaded in tests before any describe block is actually executed.

Closes #19 
Closes #28 