### PR TITLE
feat: add VSCode debug example

### DIFF
--- a/.templates/vscode/launch.json
+++ b/.templates/vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  // Copy this file to .vscode/launch.json
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug: Serverless Offline",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      // Use the package.json script
+      // instead of calling serverless offline directly because:
+      // 1. Doesn't require a locally installed sls
+      // 2. Uses a pre-configured call to sls offline (i.e. passing the api key)
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": [
+        "offline"
+      ],
+      "sourceMaps": true,
+      "protocol": "inspector",
+      "outFiles": ["${workspaceFolder}/.webpack/**/*.js"],
+      "env": {
+        "SLS_DEBUG": "*", // More debug info
+        "WEBPACK_MODE": "development" // Creates the source maps
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repo includes a pre-configured template for the VS Code NodeJS Debugger. It
 
 To get started with debugging, copy the file to `.vscode/launch.json`, or copy its contents to your existing `.vscode/launch.json` file.
 
-Now you can press `CTRL+SHIFT+D` to open the `Run` tab and execute the `Debug: Serverless Offline` configuration.
+Now you can press `CTRL+SHIFT+D` (Windows/Linux) or `SHIFT+CMD+D` (Mac) to open the `Run` tab and execute the `Debug: Serverless Offline` configuration.
 
 The configuration will spawn a `yarn offline` process, so you can configure your execution directly from `package.json`. It will also add `SLS_DEBUG=*` for more extensive logs and `WEBPACK_MODE=development` to produce source maps.
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,24 @@ For local development you can simulate lambda and an API endpoint locally using
 the following command.
 
 ```bash
-serverless offline start
+yarn offline
 ```
 
 This repository uses JavaScript import aliases with Webpack. If you are using VS Code, the `jsconfig.json` file should handle the autocompletion for you. If you are using WebStorm, you can refer to [this stackoverflow thread](https://stackoverflow.com/questions/34943631/path-aliases-for-imports-in-webstorm).
+
+## Debugging (VS Code)
+
+This repo includes a pre-configured template for the VS Code NodeJS Debugger. It can be found at `.templates/vscode/launch.json`.
+
+To get started with debugging, copy the file to `.vscode/launch.json`, or copy its contents to your existing `.vscode/launch.json` file.
+
+Now you can press `CTRL+SHIFT+D` to open the `Run` tab and execute the `Debug: Serverless Offline` configuration.
+
+The configuration will spawn a `yarn offline` process, so you can configure your execution directly from `package.json`. It will also add `SLS_DEBUG=*` for more extensive logs and `WEBPACK_MODE=development` to produce source maps.
+
+For more information on debugging on VS Code, see:
+https://code.visualstudio.com/docs/editor/debugging
+
 
 ## Testing
 


### PR DESCRIPTION
A `vscode-template/tasks.json` file will be added, as a debug configuration example to be copied over other repositories.

See:
- [ENG-42]

[ENG-42]: https://comicrelief.atlassian.net/browse/ENG-42