### PR TITLE
ci: Run `check-fixup-commits` on `ubuntu-latest`

### DIFF
--- a/.github/workflows/git-checks.yml
+++ b/.github/workflows/git-checks.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   check-fixup-commits:
     name: Check for fixup commits
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2.0.0


### PR DESCRIPTION
Ubuntu 18.04 is no longer supported, which is why the job never gets picked up by a runner and eventually fails.

Using `ubuntu-latest` will avoid this problem in the future!