### PR TITLE
chore: Add AWS tags for Lumigo

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -45,4 +45,4 @@ custom:
     lambdaPort: 3002
     noPrependStageInUrl: true
     babelOptions:
-      presets: [ "env" ]
+      presets: ["env"]

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,6 +16,7 @@ provider:
     service: ${self:service}
     stage: ${sls:stage}
     service-stage: ${self:service}-${sls:stage}
+    lumigo:auto-trace: "true"
 
   environment:
     EPSAGON_TOKEN: ${env:EPSAGON_TOKEN, ""}

--- a/serverless.yml
+++ b/serverless.yml
@@ -12,6 +12,11 @@ provider:
   region: ${env:AWS_REGION, env:AWS_DEFAULT_REGION, 'eu-west-1'}
   stage: ${opt:stage, 'dev'}
   versionFunctions: false
+  stackTags:
+    service: ${self:service}
+    stage: ${sls:stage}
+    service-stage: ${self:service}-${sls:stage}
+
   environment:
     EPSAGON_TOKEN: ${env:EPSAGON_TOKEN, ""}
     EPSAGON_SERVICE_NAME: ${env:EPSAGON_SERVICE_NAME, ""}
@@ -39,4 +44,4 @@ custom:
     lambdaPort: 3002
     noPrependStageInUrl: true
     babelOptions:
-      presets: ["env"]
+      presets: [ "env" ]


### PR DESCRIPTION
Adds AWS tags to all Lambda functions that identify which service they belong to and what stage they're in, to help us group things within Lumigo.

Also adds the `lumigo:auto-trace` tag which ensures any new functions that we add will be automatically auto-traced.

Jira: [ENG-2761]

[ENG-2761]: https://comicrelief.atlassian.net/browse/ENG-2761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ