### PR TITLE
fix: Use `aws:region` and `sls:stage` Serverless vars

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -9,8 +9,8 @@ provider:
   runtime: nodejs18.x
   memorySize: 128
   timeout: 60
-  region: ${env:AWS_REGION, env:AWS_DEFAULT_REGION, 'eu-west-1'}
-  stage: ${opt:stage, 'dev'}
+  region: eu-west-1
+  stage: dev
   versionFunctions: false
 
   stackTags:
@@ -23,8 +23,8 @@ provider:
   environment:
     EPSAGON_TOKEN: ${env:EPSAGON_TOKEN, ""}
     EPSAGON_SERVICE_NAME: ${env:EPSAGON_SERVICE_NAME, ""}
-    REGION: ${self:provider.region}
-    STAGE: ${self:provider.stage}
+    REGION: ${aws:region}
+    STAGE: ${sls:stage}
 
 functions:
   - ${file(./serverless/functions/hello.yml)}


### PR DESCRIPTION
Removes the need for conditional/fallback logic in `provider.region` and `provider.stage`. Existing logic for `region` was flawed, since it ignored the CLI `--region` option. These two keys now simply store the defaults.